### PR TITLE
Increase maximum font size from 40 to 100

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2625,3 +2625,4 @@ var powerbi;
         })(utils = extensibility.utils || (extensibility.utils = {}));
     })(extensibility = powerbi.extensibility || (powerbi.extensibility = {}));
 })(powerbi || (powerbi = {}));
+//# sourceMappingURL=index.js.map

--- a/lib/index.js
+++ b/lib/index.js
@@ -1757,7 +1757,7 @@ var powerbi;
                      * Stored in terms of 'pt'
                      * Convert to pixels using PixelConverter.fromPoint
                      */
-                    TextSizeDefaults.TextSizeMax = 40;
+                    TextSizeDefaults.TextSizeMax = 100;
                     var TextSizeRange = TextSizeDefaults.TextSizeMax - TextSizeDefaults.TextSizeMin;
                     /**
                      * Returns the percentage of this value relative to the TextSizeMax

--- a/src/textSizeDefaults.ts
+++ b/src/textSizeDefaults.ts
@@ -42,7 +42,7 @@ module powerbi.extensibility.utils.type {
          * Stored in terms of 'pt'
          * Convert to pixels using PixelConverter.fromPoint
          */
-        export const TextSizeMax: number = 40;
+        export const TextSizeMax: number = 100;
 
         const TextSizeRange: number = TextSizeMax - TextSizeMin;
 

--- a/test/textSizeDefaultsTest.ts
+++ b/test/textSizeDefaultsTest.ts
@@ -32,7 +32,7 @@ module powerbi.extensibility.utils.type.test {
     describe("TextSizeDefaults", () => {
 
         it("getScale", () => {
-            expect(TextSizeDefaults.getScale(24)).toBeCloseTo(0.50, 1);
+            expect(TextSizeDefaults.getScale(24)).toBeCloseTo(0.17, 1);
         });
     });
 }


### PR DESCRIPTION
This allows visuals to use bigger fonts (in e.g. Synoptic panel). The number 100 is an arbitrary choice. We've seen scenarios where we wanted to use font size 72.