### PR TITLE
fix double.roundToPrecision

### DIFF
--- a/src/double.ts
+++ b/src/double.ts
@@ -369,7 +369,7 @@ export function ceilToPrecision(x: number, precision?: number): number {
  * @param precision Precision value.
  */
 export function roundToPrecision(x: number, precision?: number): number {
-    precision = detectPrecision(precision, DEFAULT_PRECISION);
+    precision = detectPrecision(precision, x);
 
     if (precision === 0 || x === 0) {
         return x;

--- a/test/doubleTest.ts
+++ b/test/doubleTest.ts
@@ -178,6 +178,11 @@ describe("Double", () => {
         expect(Double.roundToPrecision(1.40000000001E-207, 1E-208)).toBe(1.4E-207);
         expect(Double.roundToPrecision(1.41E-207, 1E-208)).toBe(1.4E-207);
         expect(Double.roundToPrecision(1.41E-207, 1E-209)).toBe(1.41E-207);
+
+        expect(Double.roundToPrecision(.2)).toBe(.2);
+        expect(Double.roundToPrecision(1.2)).toBe(1.2);
+        expect(Double.roundToPrecision(11.2)).toBe(11.2);
+        expect(Double.roundToPrecision(111.2)).toBe(111.2);
     });
 
     it("Double removeDecimalNoise()", () => {


### PR DESCRIPTION
This fixes #34. The issue turned out to be not the rounding itself but the calling of `detectPrecision` in a wrong way. Let's look at the implementation of `detectPrecision`:
https://github.com/microsoft/powerbi-visuals-utils-typeutils/blob/c6485adf192418f8bb78982c5ee3050144659f99/src/double.ts#L472-L487

As I understand if it get's passed a precision that is not null it just returns it. If precision is null then it detects the precision based on the boundary values **x** and **y**. If the precision is null it returns **DEFAULT_PRECISION**.  
So the call
https://github.com/microsoft/powerbi-visuals-utils-typeutils/blob/c6485adf192418f8bb78982c5ee3050144659f99/src/double.ts#L356
in double.roundToPrecision does not make sense. As I understand it should pass **x** instead of **DEFAULT_PRECISION**.  
I also added some more test cases to verify my problems were fixed. All tests pass for me.